### PR TITLE
Add 'Open with Codeanywhere' badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ https://github.com/fxdave/cuple/assets/12275699/a9486ab2-6d61-467b-acd2-1a9acc6b
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/~/github.com/fxdave/react-express-cuple-boilerplate/tree/stackblitz?file=backend/src/index.ts)
 
+[![Open in Codeanywhere](https://codeanywhere.com/img/open-in-codeanywhere-btn.svg)](https://app.codeanywhere.com/#https://github.com/fxdave/react-express-cuple-boilerplate/)
+
 ### About RPCs in general
 
 RPC stands for Remote Procedure Call. You define procedures in the server, and you call them from the client.


### PR DESCRIPTION
With Codeanywhere, developers and contributors can instantly launch a cloud or local IDE with a pre-configured remote development environment. One can work in the cloud or locally, and it ensures all contributors have access to the same, ready-to-use dev env.